### PR TITLE
Fixed 1422 (click add/remove icon in slideshow freezes opus) and 1421 (spacebar scroll the window)

### DIFF
--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -3104,16 +3104,16 @@ var o_browse = {
             let buttonInfo = o_browse.cartButtonInfo(action);
 
             // prev/next buttons - put this in op-metadata-detail-view html...
-            let html = `<div class="col"><a href="#" class="op-cart-toggle" data-id="${opusId}"><i class="${buttonInfo[tab].icon} fa-2x float-left op-metadatabox-tooltip" title="${buttonInfo[tab].title} (or press spacebar)"></i></a></div>`;
+            let html = `<div class="col"><a href="#" class="op-cart-toggle op-metadatabox-tooltip" data-id="${opusId}" title="${buttonInfo[tab].title} (or press spacebar)"><i class="${buttonInfo[tab].icon} fa-2x float-left"></i></a></div>`;
             html += `<div class="col text-center op-obs-direction">`;
             let opPrevDisabled = (nextPrevHandles.prev == "" ? "op-button-disabled" : "");
             let opNextDisabled = (nextPrevHandles.next == "" ? "op-button-disabled" : "");
-            html += `<a href="#" class="op-prev text-center ${opPrevDisabled}" data-id="${nextPrevHandles.prev}"><i class="far fa-arrow-alt-circle-left fa-2x  op-metadatabox-tooltip" title="Previous image: ${nextPrevHandles.prev} (left arrow key)"></i></a>`;
-            html += `<a href="#" class="op-next ${opNextDisabled}" data-id="${nextPrevHandles.next}"><i class="far fa-arrow-alt-circle-right fa-2x op-metadatabox-tooltip" title="Next image: ${nextPrevHandles.next} (right arrow key)"></i></a>`;
+            html += `<a href="#" class="op-prev op-metadatabox-tooltip text-center ${opPrevDisabled}" data-id="${nextPrevHandles.prev}" title="Previous image: ${nextPrevHandles.prev} (left arrow key)"><i class="far fa-arrow-alt-circle-left fa-2x "></i></a>`;
+            html += `<a href="#" class="op-next op-metadatabox-tooltip ${opNextDisabled}" data-id="${nextPrevHandles.next}" title="Next image: ${nextPrevHandles.next} (right arrow key)"><i class="far fa-arrow-alt-circle-right fa-2x"></i></a>`;
             html += `</div>`;
 
             // mini-menu like the hamburger on the observation/gallery page
-            html += `<div class="col text-start"><a href="#" class="menu pe-3 float-end text-center" role="button" data-id="${opusId}"><i class="fas fa-bars fa-2x op-metadatabox-tooltip" title="More options"></i></a></div>`;
+            html += `<div class="col text-start"><a href="#" class="menu op-metadatabox-tooltip pe-3 float-end text-center" role="button" data-id="${opusId}" title="More options"><i class="fas fa-bars fa-2x"></i></a></div>`;
             $(".op-metadata-detail-view-body .bottom").html(html);
 
             // update the binoculars here
@@ -3135,7 +3135,19 @@ var o_browse = {
                 maxWidth: opus.tooltipsMaxWidth,
                 theme: opus.tooltipsTheme,
                 delay: opus.tooltipsDelay,
+                contentAsHTML: true,
+                functionPosition: function(instance, helper, position){
+                    // Set the positions of tooltips at the middle of the icons in metadatabox
 
+                    // Get the position and size of the "i" tag (the icon)
+                    let iconRec = instance._$origin[0].firstChild.getBoundingClientRect();
+
+                    // make sure tooltips stay at the top and middle of the icon with some spaces (10 in this case)
+                    position.coord.top = iconRec.top - iconRec.height - 10;
+                    position.target = iconRec.left + (iconRec.width / 2);
+
+                    return position;
+                }
             });
 
             $(".op-metadatabox-img-tooltip").tooltipster({

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -3140,7 +3140,7 @@ var o_browse = {
                     // Set the positions of tooltips at the middle of the icons in metadatabox
 
                     // Get the position and size of the "i" tag (the icon)
-                    let iconRec = instance._$origin[0].firstChild.getBoundingClientRect();
+                    let iconRec = helper.origin.firstChild.getBoundingClientRect();
 
                     // make sure tooltips stay at the top and middle of the icon with some spaces (10 in this case)
                     position.coord.top = iconRec.top - iconRec.height - 10;

--- a/opus/application/static_media/js/browse.js
+++ b/opus/application/static_media/js/browse.js
@@ -3108,7 +3108,7 @@ var o_browse = {
             html += `<div class="col text-center op-obs-direction">`;
             let opPrevDisabled = (nextPrevHandles.prev == "" ? "op-button-disabled" : "");
             let opNextDisabled = (nextPrevHandles.next == "" ? "op-button-disabled" : "");
-            html += `<a href="#" class="op-prev op-metadatabox-tooltip text-center ${opPrevDisabled}" data-id="${nextPrevHandles.prev}" title="Previous image: ${nextPrevHandles.prev} (left arrow key)"><i class="far fa-arrow-alt-circle-left fa-2x "></i></a>`;
+            html += `<a href="#" class="op-prev op-metadatabox-tooltip text-center ${opPrevDisabled}" data-id="${nextPrevHandles.prev}" title="Previous image: ${nextPrevHandles.prev} (left arrow key)"><i class="far fa-arrow-alt-circle-left fa-2x"></i></a>`;
             html += `<a href="#" class="op-next op-metadatabox-tooltip ${opNextDisabled}" data-id="${nextPrevHandles.next}" title="Next image: ${nextPrevHandles.next} (right arrow key)"><i class="far fa-arrow-alt-circle-right fa-2x"></i></a>`;
             html += `</div>`;
 

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -973,6 +973,13 @@ var opus = {
                     break;
             }
         });
+
+        // Prevent the spacebar from scrolling the perfect scrollbar
+        $(".ps__thumb-y").on("keydown", function(e) {
+            if (e.code === "Space") {
+                e.preventDefault();
+            }
+        });
     },
 
     tooltipClickHandler: function () {

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -973,6 +973,13 @@ var opus = {
                     break;
             }
         });
+
+        // Prevent the spacebar from scrolling the perfect scrollbar
+        $(".ps__thumb-y").on("keydown", function(e) {
+            if (e.code === "Space") {
+                e.preventDefault();
+            }
+        });
     },
 
     tooltipClickHandler: function () {
@@ -1195,13 +1202,6 @@ var opus = {
             o_browse.initInfiniteScroll(tab, `#${tab} .op-gallery-view`);
             o_browse.initInfiniteScroll(tab, `#${tab} .op-data-table-view`);
         }
-
-        // Prevent the spacebar from scrolling the perfect scrollbar
-        $(".ps__thumb-y").on("keydown", function(e) {
-            if (e.code === "Space") {
-                e.preventDefault();
-            }
-        });
 
         o_cart.initCart();
         o_detail.showDetailThumbInNav();

--- a/opus/application/static_media/js/opus.js
+++ b/opus/application/static_media/js/opus.js
@@ -973,13 +973,6 @@ var opus = {
                     break;
             }
         });
-
-        // Prevent the spacebar from scrolling the perfect scrollbar
-        $(".ps__thumb-y").on("keydown", function(e) {
-            if (e.code === "Space") {
-                e.preventDefault();
-            }
-        });
     },
 
     tooltipClickHandler: function () {
@@ -1202,6 +1195,13 @@ var opus = {
             o_browse.initInfiniteScroll(tab, `#${tab} .op-gallery-view`);
             o_browse.initInfiniteScroll(tab, `#${tab} .op-data-table-view`);
         }
+
+        // Prevent the spacebar from scrolling the perfect scrollbar
+        $(".ps__thumb-y").on("keydown", function(e) {
+            if (e.code === "Space") {
+                e.preventDefault();
+            }
+        });
 
         o_cart.initCart();
         o_detail.showDetailThumbInNav();


### PR DESCRIPTION
- Fixes #1422
- Fixes #1421 
- Is a new database import required? N
- Were test and deploy scripts reviewed for necessary changes? NA
- Were any JavaScript or CSS files modified? Y
  - If YES:
    - JSHINT run on all affected files: Y
    - Tested on Chrome, Firefox, Safari, Edge, and iOS: Y
      (Remember to test all browser sizes)
    - Tested for race conditions (with delayed API calls if applicable): Y
- Was the documentation reviewed for necessary changes or additions? NA
  - About
  - Getting Started
  - FAQ
  - API Guide
  - Tooltips
  - Import/database schema

Description of changes:

1422:
The main reason that caused the hang was because we attached tooltips at the "i" tags (the icons), and later on we modified the "i" tags without putting back "tooltipstered" class in `updateCartIcon`. Now we attached the tooltips at the container "a" tags just like what we've done to other icons to avoid remove/add "tooltipstered" class, the hang is fixed.

1421:
By default, perfect scrollbar allows spacebar to scroll the window (line 690-696, perfect-scrollbar.js). That's why when we hit the space key, the window will scroll. Now we attach a keydown event listener to the perfect scrollbar, and whenever the space key is hit, we do prevent default to stop the event propagation. That way the perfect scrollbar won't scroll. The expected behavior will be the same as described in the issue page: in gallery/table view, the spacebar won't do anything, and in the slideshow, the spacebar will add/remove the current obs. 

Changes:
- Move 'op-metadatabox-tooltip' class to the "a" tags that contain the add/remove, prev/next, and hamburger icons ("i" tags). This will prevent us from modifying "tooltipstered" class at at line 2853 in `updateCartIcon`. 
- Properly position the tooltips at the top and middle of the add/remove, prev/next, and hamburger icons in the metadata box.
- Add a keydown event listener to the perfect scrollbar, and when the space key is hit, we do prevent default to stop the event propagation so that the scrollbar won't scroll.

Known problems:
NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Tooltips now attach to surrounding controls (anchors), improving hit areas and accessibility.
  * Tooltips support HTML content and use refined, icon-relative positioning for richer, better‑placed metadata and control help.

* **Bug Fixes**
  * Prevented the Space key from unintentionally scrolling embedded scroll areas, improving keyboard navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->